### PR TITLE
moved upward github section

### DIFF
--- a/src/Components/Header/Header.scss
+++ b/src/Components/Header/Header.scss
@@ -37,6 +37,8 @@ header {
     font-size: 3vmin;
     font-weight: 800;
     color: #efe4e4;
+    position: relative;
+    top: -80px;
     span {
       line-height: 2vmax;
       letter-spacing: 0.5vmax;
@@ -168,7 +170,7 @@ header {
     letter-spacing: -0.025em;
     z-index: 2;
     opacity: 1;
-    text-shadow: #FEEA3A 5px 10px 10px;
+    text-shadow: #feea3a 5px 10px 10px;
     span {
       display: block;
       font-size: 12vmin;


### PR DESCRIPTION
Closes #190 opened by @XanderRubio 
 Alinged the Github_section with the image on the left side of header

![Screenshot 2023-10-12 222156](https://github.com/BeforeIDieCode/BeforeIDieAchievements/assets/118172073/95207fda-027d-4f3f-afc0-0a686c57df4f)


- [✔️] I have thoroughly read and understand [The Contribution Guidelines](https://github.com/BeforeIDieCode/BeforeIDieAchievements/blob/main/CONTRIBUTION-GUIDELINES.md).
- [✔️ ] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
  - `Feature` - adds new or amends existing user-facing behavior.
  - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc.
  - `Fix` - bug fixes.
  - `Docs` - fixing typos and adding new content.
- [✔️ ] I have listed my proposed changes and their benefits.
- [ ✔️] I have linked the corresponding issue in the Issues section.
