### PR TITLE
fixed playing issue on hover

### DIFF
--- a/src/Components/Footer/Footer.jsx
+++ b/src/Components/Footer/Footer.jsx
@@ -1,18 +1,15 @@
 import React, { useState, useEffect } from "react";
-import useSound from 'use-sound';
-import heartBeat from './heart-beat.wav';
-import typingSound from './typing-sound.wav';
-
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faCode } from '@fortawesome/free-solid-svg-icons';
+import heartBeat from "./heart-beat.wav";
+import typingSound from "./typing-sound.wav";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faCode } from "@fortawesome/free-solid-svg-icons";
 
 import styles from "./Footer.module.css";
 
 const Footer = () => {
   const [isMobile, setIsMobile] = useState(window.innerWidth < 640);
-  const [playHeartBeat, { stop: stopHeartBeat }] = useSound(heartBeat);
-  const [playTypingSound, { stop: stopTypingSound }] = useSound(typingSound);
-
+  const heartAudio = new Audio(heartBeat);
+  const typingAudio = new Audio(typingSound);
   useEffect(() => {
     function handleSize() {
       setIsMobile(window.innerWidth < 640);
@@ -21,24 +18,44 @@ const Footer = () => {
 
     return () => {
       window.removeEventListener("resize", handleSize);
-    }
-  }, [])
+    };
+  }, []);
 
+  const playHeartbeat = () => {
+    heartAudio.play();
+  };
+  const stopHeartbeat = () => {
+    if (heartAudio) {
+      heartAudio.pause();
+    }
+  };
+  const playTypingSound = () => {
+    typingAudio.play();
+  };
+  const stopTypingSound = () => {
+    if (typingAudio) {
+      typingAudio.pause();
+    }
+  };
   return (
     <footer className={styles["footer"]}>
       <p className={styles["footer-message"]}>
-      <span
-      onMouseEnter={playTypingSound}
-      onMouseLeave={stopTypingSound}
-      >
-        <FontAwesomeIcon icon={faCode} style={{color: "#feea3a"}} />
-      </span> with{" "}
+        <span
+          onMouseEnter={playTypingSound}
+          onMouseLeave={stopTypingSound}
+        >
+          <FontAwesomeIcon
+            icon={faCode}
+            style={{ color: "#feea3a" }}
+          />
+        </span>{" "}
+        with{" "}
         <span
           className={styles["emoji"]}
-          role='img'
-          aria-label='heart'
-          onMouseEnter={playHeartBeat}
-          onMouseLeave={stopHeartBeat}
+          role="img"
+          aria-label="heart"
+          onMouseEnter={playHeartbeat}
+          onMouseLeave={stopHeartbeat}
         >
           💙
         </span>{" "}
@@ -46,7 +63,8 @@ const Footer = () => {
         by the{" "}
         <a
           className={styles["footer-message-link"]}
-          href='https://github.com/BeforeIDieCode'>
+          href="https://github.com/BeforeIDieCode"
+        >
           Before I Die Community
         </a>
       </p>


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

Issue #207 

<!-- If your PR fixes an open issue, use `Closes` and add the issue number to link it to your PR -->

 Closes #207 

## Proposed Changes and Benefits
hovering and unhovering on footer emojis did not work well 
in chrome when emoji was hovered the audio started to play but by unhoveing it still played and if you hovered again you could listen the audio double at the same time.
in firefox , you have to click on the emojis to audio started to play and it wouldn't stop
I fixed them buy Audio built-in class and added some functions 




### Checklist
  - `Fix` - bug fixes.

